### PR TITLE
(feat, refactor, bugfix, docs) see below:

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -14,3 +14,4 @@ mapAF3.js
 test.js
 scratchPad.js
 notes.txt
+logAFOptions/

--- a/bower.json
+++ b/bower.json
@@ -55,6 +55,7 @@
     "mapAF3.js",
     "package-lock.json",
     "test.js",
-    "notes.txt"
+    "notes.txt",
+    "logAFOptions"
   ]
 }

--- a/logAF.js
+++ b/logAF.js
@@ -19,6 +19,8 @@ const logAF = function logAF(...items) {
     Promise.resolve(items[0]).then(item => firstItem = item);
     const lineNum = logAF.setFormat(firstItem);
     items.unshift(lineNum);
+  } else {
+    items.unshift('');
   }
   Promise.all(items).then((toLog) => {
     if (logAF.duration) {
@@ -104,6 +106,111 @@ logAF.setFormat = function setFormat(firstArg) {
   }
   return formats[logAF.labelFormat]();
 };
+
+/**
+ * Sets logging options for the logAF method;
+ * accepts an options Object with the following optional properties:
+ * - label (Boolean) - set to false to disable logging the location of calls to logAF
+ * - duration (Boolean) - set to false to disable logging the time it takes (in secs) to complete each call to logAF
+ * - labelFormat (String) - alters the format of logAF labels; choose between file (default), path, parent, arrow, or custom
+ *
+ * **For example:**
+ * ```javascript
+ * const {logAF} = require('async-af');
+ *
+ * const promise = () => new Promise(resolve => setTimeout(() => resolve(1), 1000));
+ * ```
+ * **default logging**
+ * ```javascript
+ * logAF(promise(), 2);
+ * // @filename.js:212:9: 1 2
+ * // in 0.998 secs
+ * ```
+ * **turn off label**
+ * ```javascript
+ * logAF.options({ label: false });
+ * logAF(promise(), 2);
+ * //  1 2
+ * // in 0.999 secs
+ * ```
+ * **turn off duration**
+ * ```javascript
+ * logAF.options({ duration: false });
+ * logAF(promise(), 2);
+ * // @filename.js:212:9: 1 2
+ * ```
+ * **change labelFormat**
+ * file (default)
+ * ```javascript
+ * logAF.options({ labelFormat: file });
+ * logAF(promise(), 2);
+ * // @filename.js:212:9: 1 2
+ * // in 0.998 secs
+ * ```
+ * path
+ * ```javascript
+ * logAF.options({ labelFormat: path });
+ * logAF(promise(), 2);
+ * // @/Path/to/current/directory/filename.js:212:9:
+ * // 1 2
+ * // in 0.997 secs
+ * ```
+ * parent
+ * ```javascript
+ * logAF.options({ labelFormat: parent });
+ * logAF(promise(), 2);
+ * // @parentDirectory/filename.js:213:9: 1 2
+ * // in 0.998 secs
+ * ```
+ * arrow
+ * ```javascript
+ * logAF.options({ labelFormat: arrow });
+ * logAF(promise(), 2);
+ * // ========================> 1 2
+ * // in 0.999 secs
+ * ```
+ * custom (create your own labelFormat)
+ * - to set a custom labelFormat, first set it to a String starting with `'custom='`
+ * - after `custom=`, insert your desired format as a String
+ * (a String within a String)
+ *
+ * ```javascript
+ * logAF.options({ labelFormat: 'custom="I logged this:"' });
+ * logAF(promise(), 2);
+ * // I logged this: 1 2
+ * // in 1.000 secs
+ * ```
+ *
+ * - your custom format can also access location information as variables, including
+ * `file`, `path`, `parent`, and `arrow`
+ *
+ * e.g., to set the labelFormat to `file:line:col =>` you can use template literals
+ * ```javascript
+ * logAF.options({ labelFormat: 'custom=`${file}:${line}:${col} =>`' });
+ * logAF(promise(), 2);
+ * // filename.js:212:9 => 1 2
+ * // in 0.998 secs
+ * ```
+ *
+ * and just to demonstrate all the location variables in one custom format
+ * ```javascript
+ * logAF.options({
+ *   labelFormat: 'custom=`${arrow}\nline: ${line}\ncol: ${col}\nparent: ${parent}\nfile: ${file}\npath: ${path}`'
+ * });
+ * // ========================>
+ * // line: 212
+ * // col: 9
+ * // parent: parentDirectory/
+ * // file: filename.js
+ * // path: /Path/to/current/directory/ 1 2
+ * // in 0.998 secs
+ * ```
+ *
+ * @param {Object} options - the options for logAF
+ * @param {Boolean} [options.label]
+ * @param {Boolean} [options.duration=true]
+ * @param {string} [options.labelFormat=file]
+ */
 
 logAF.options = function logAFOptions(options) {
   if (options.label === false) logAF.label = false;

--- a/logAF.js
+++ b/logAF.js
@@ -1,8 +1,18 @@
 /**
- * - Logs items to the console; if an item is a promise,
- * logAF will first resolve the promise then log its value.
+ * - Logs items to the console
+ * - if an item is a promise, logAF will first resolve the promise then log its value
  *
- * - **Note:** The label (file:line:col) may not work correctly
+ * Example:
+ * ```javascript
+ * const {logAF} = require('async-af');
+ *
+ * const promise = () => new Promise(resolve => setTimeout(() => resolve(1), 1000));
+ *
+ * logAF(promise(), 2);
+ * // @filename.js:212:9: 1 2
+ * // in 0.998 secs
+ * ```
+ * **Note:** The label may not work correctly
  * in all environments; to turn the label off, set label to false
  * in logAF options, where you can also change the label's format.
  *

--- a/logAF.js
+++ b/logAF.js
@@ -21,8 +21,8 @@ const logAF = function logAF(...items) {
     items.unshift(lineNum);
   }
   Promise.all(items).then((toLog) => {
-    const end = Date.now();
     if (logAF.duration) {
+      const end = Date.now();
       const numberOf = ((end - start) / 1000).toFixed(3);
       toLog.push(`\nin ${numberOf} secs`);
     }

--- a/logAF.js
+++ b/logAF.js
@@ -18,9 +18,12 @@ const logAF = function logAF(...items) {
     items.unshift(lineNum);
   }
   Promise.all(items).then((toLog) => {
-    // eslint-disable-next-line
     const end = Date.now();
-    if (logAF.duration) toLog.push(`\nin ${((end - start) / 1000).toFixed(3)} secs`);
+    if (logAF.duration) {
+      const numberOf = ((end - start) / 1000).toFixed(3);
+      toLog.push(`\nin ${numberOf} secs`);
+    }
+    // eslint-disable-next-line
     console ? console.log ? console.log(...toLog) : null : null;
   });
 };

--- a/logAF.js
+++ b/logAF.js
@@ -12,18 +12,22 @@
  */
 
 const logAF = function logAF(...items) {
+  const start = Date.now();
   if (logAF.label) {
     const lineNum = logAF.setFormat(items[0]);
     items.unshift(lineNum);
   }
   Promise.all(items).then((toLog) => {
     // eslint-disable-next-line
+    const end = Date.now();
+    if (logAF.duration) toLog.push(`\nin ${((end - start) / 1000).toFixed(3)} secs`);
     console ? console.log ? console.log(...toLog) : null : null;
   });
 };
 
 logAF.label = true;
 logAF.labelFormat = 'file';
+logAF.duration = true;
 
 /*
 * labelFormat options:
@@ -92,6 +96,7 @@ logAF.setFormat = function setFormat(firstArg) {
 
 logAF.options = function logAFOptions(options) {
   if (options.label === false) logAF.label = false;
+  if (options.duration === false) logAF.duration = false;
   if (options.labelFormat) {
     const validFormats = [
       'file',

--- a/logAF.js
+++ b/logAF.js
@@ -63,7 +63,12 @@ logAF.setFormat = function setFormat(firstArg) {
   const error = new Error();
   if (!error.stack) return '';
   const newLineForObjs = typeof firstArg === 'object' ? '\n' : '';
-  const target = error.stack.lastIndexOf`/`;
+  let target = error.stack.lastIndexOf`/`;
+  // to avoid next_tick.js filename:
+  if (error.stack.slice(target).includes`next_tick`) {
+    error.stack = error.stack.split`\n`.slice(0, 4).join`\n`;
+    target = error.stack.lastIndexOf`/`;
+  }
   const formats = {
     file() {
       const end = error.stack.indexOf(')', target + 1);

--- a/logAF.js
+++ b/logAF.js
@@ -1,9 +1,22 @@
-const logAF = function logAF(...args) {
+/**
+ * - Logs items to the console; if an item is a promise,
+ * logAF will first resolve the promise then log its value.
+ *
+ * - **Note:** The label (file:line:col) may not work correctly
+ * in all environments; to turn the label off, set label to false
+ * in logAF options, where you can also change the label's format.
+ *
+ * @since 1.3.0
+ * @param {*} items The items to print (log to the console)
+ * @see logAF.options to turn the label off or change its format
+ */
+
+const logAF = function logAF(...items) {
   if (logAF.label) {
-    const lineNum = logAF.setFormat(args[0]);
-    args.unshift(lineNum);
+    const lineNum = logAF.setFormat(items[0]);
+    items.unshift(lineNum);
   }
-  Promise.all(args).then((toLog) => {
+  Promise.all(items).then((toLog) => {
     // eslint-disable-next-line
     console ? console.log ? console.log(...toLog) : null : null;
   });

--- a/logAF.js
+++ b/logAF.js
@@ -14,7 +14,10 @@
 const logAF = function logAF(...items) {
   const start = Date.now();
   if (logAF.label) {
-    const lineNum = logAF.setFormat(items[0]);
+    let firstItem;
+    // eslint-disable-next-line no-return-assign
+    Promise.resolve(items[0]).then(item => firstItem = item);
+    const lineNum = logAF.setFormat(firstItem);
     items.unshift(lineNum);
   }
   Promise.all(items).then((toLog) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "async-af",
-  "version": "1.6.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "async/await fun",
   "author": "Scott Rudiger (https://github.com/ScottRudiger)",
   "license": "MIT",
-  "version": "1.6.0",
+  "version": "2.0.0",
   "homepage": "https://github.com/AsyncAF/AsyncAF#readme",
   "bugs": {
     "url": "https://github.com/AsyncAF/AsyncAF/issues"


### PR DESCRIPTION
(docs) add JSDoc docs to logAF
(feat) add time duration option to logAF
(bugfix) fix bug where \n is applied to all Promises rather than their resolve values
(bugfix) avoid filename showing as 'next_tick.js' when using logAF inside looping AsyncAF methods
(publish) ignore a couple files before publishing
(docs) add jsDocs for logAF.options
(bugfix) fix bug where escaped characters were showing when setting label to false
(docs) add example for logAF